### PR TITLE
Change content-type of ticket article body (Fixes Issue #45)

### DIFF
--- a/includes/functions/hf-plugin-integration.php
+++ b/includes/functions/hf-plugin-integration.php
@@ -240,7 +240,7 @@ if (!function_exists('zammad_hf_process_form_action')) {
                 'sender'        => 'Customer',
                 'subject'       => $subject,
                 'body'          => $message,
-                'content_type'  => 'text/html',
+                'content_type'  => 'text/plain',
                 'type'          => 'web',
                 'internal'      => false,
 				'attachments'	=> $attachments


### PR DESCRIPTION
Change the content-type from `text\html` to `text\plain` in order for the Zammad instance to be able to parse line breaks in the message correctly.  (Fixes Issue #45) 